### PR TITLE
Add reminder pagination and cleanup

### DIFF
--- a/src/plugins/remind/commands/remind.ts
+++ b/src/plugins/remind/commands/remind.ts
@@ -79,7 +79,7 @@ export const remind = {
     }
     
     try {
-      await subcommand.handler(interaction);
+      await subcommand.execute(interaction);
     } catch (error) {
       console.error(`Error executing remind subcommand "${subcommandName}":`, error);
       

--- a/src/plugins/remind/commands/subcommands/deleteReminder.ts
+++ b/src/plugins/remind/commands/subcommands/deleteReminder.ts
@@ -1,18 +1,14 @@
-import { 
-  ChatInputCommandInteraction, 
-  EmbedBuilder, 
-  MessageFlags 
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags
 } from 'discord.js';
 import { Reminder } from '../../../../db/models';
-
-export interface SubcommandHandler {
-  name: string;
-  handler: (interaction: ChatInputCommandInteraction) => Promise<void>;
-}
+import { SubcommandHandler } from '../../../types';
 
 export const deleteReminder: SubcommandHandler = {
   name: 'delete_reminder',
-  async handler(interaction: ChatInputCommandInteraction) {
+  async execute(interaction: ChatInputCommandInteraction) {
     const reminderId = interaction.options.getInteger('reminder_id', true);
     const isPublic = interaction.options.getBoolean('public') || false;
     

--- a/src/plugins/remind/commands/subcommands/index.ts
+++ b/src/plugins/remind/commands/subcommands/index.ts
@@ -1,9 +1,4 @@
-import { ChatInputCommandInteraction } from 'discord.js';
-
-export interface SubcommandHandler {
-  name: string;
-  handler: (interaction: ChatInputCommandInteraction) => Promise<void>;
-}
+import { SubcommandHandler } from '../../../types';
 
 import { reminder } from './reminder';
 import { listReminders } from './listReminders';

--- a/src/plugins/remind/commands/subcommands/reminder.ts
+++ b/src/plugins/remind/commands/subcommands/reminder.ts
@@ -1,21 +1,17 @@
-import { 
-  ChatInputCommandInteraction, 
-  EmbedBuilder, 
-  MessageFlags 
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  MessageFlags
 } from 'discord.js';
 import { Reminder } from '../../../../db/models';
 import { enhanceReminderMessage, isGoogleAIAvailable } from '../../../../utils/googleAI';
 import { parseTimeString, formatTimeRemaining } from '../../../../utils/timeParser';
 import { detectLanguage } from '../../../../utils/languageDetector';
-
-export interface SubcommandHandler {
-  name: string;
-  handler: (interaction: ChatInputCommandInteraction) => Promise<void>;
-}
+import { SubcommandHandler } from '../../../types';
 
 export const reminder: SubcommandHandler = {
   name: 'reminder',
-  async handler(interaction: ChatInputCommandInteraction) {
+  async execute(interaction: ChatInputCommandInteraction) {
     const description = interaction.options.getString('description', true);
     const isPublic = interaction.options.getBoolean('public') || false;
     

--- a/src/plugins/remind/events/reminderListPaginationHandler.ts
+++ b/src/plugins/remind/events/reminderListPaginationHandler.ts
@@ -1,0 +1,96 @@
+import {
+  Client,
+  ButtonInteraction,
+  EmbedBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle
+} from 'discord.js';
+import { Reminder } from '../../../db/models';
+import { EventHandler } from '../../types';
+import { formatTimeRemaining } from '../../../utils/timeParser';
+
+export const reminderListPaginationHandler: EventHandler = {
+  name: 'interactionCreate',
+  async execute(client: Client, interaction: ButtonInteraction) {
+    if (!interaction.isButton()) return;
+    if (!interaction.customId.startsWith('remindlist_')) return;
+
+    const [, pageStr, showAllStr] = interaction.customId.split('_');
+    let page = parseInt(pageStr);
+    const showAll = showAllStr === '1';
+
+    if (isNaN(page)) page = 0;
+
+    const whereClause: any = {
+      userId: interaction.user.id
+    };
+    if (!showAll) {
+      whereClause.isCompleted = false;
+    }
+
+    const reminders = await Reminder.findAll({
+      where: whereClause,
+      order: [['reminderTime', 'ASC']]
+    });
+
+    const remindersPerPage = 5;
+    const totalPages = Math.ceil(reminders.length / remindersPerPage) || 1;
+    page = Math.max(0, Math.min(page, totalPages - 1));
+
+    const pageReminders = reminders.slice(page * remindersPerPage, (page + 1) * remindersPerPage);
+
+    if (reminders.length === 0) {
+      const embed = new EmbedBuilder()
+        .setColor(0xffaa00)
+        .setTitle('📋 Your Reminders')
+        .setDescription(showAll ? 'You have no reminders.' : 'You have no active reminders.')
+        .setTimestamp();
+
+      await interaction.update({ embeds: [embed], components: [] });
+      return;
+    }
+
+    const embed = new EmbedBuilder()
+      .setColor(0x0099ff)
+      .setTitle('📋 Your Reminders')
+      .setDescription(`Page ${page + 1} of ${totalPages}`)
+      .setTimestamp();
+
+    const now = new Date();
+
+    for (const reminder of pageReminders) {
+      const isPast = new Date(reminder.reminderTime) < now;
+      const timeDisplay = isPast
+        ? `⏰ <t:${Math.floor(new Date(reminder.reminderTime).getTime() / 1000)}:R> (Overdue)`
+        : `⏰ <t:${Math.floor(new Date(reminder.reminderTime).getTime() / 1000)}:R>`;
+      const status = reminder.isCompleted ? '✅ Completed' : isPast ? '🔴 Overdue' : '🟢 Active';
+      const title = reminder.enhancedTitle || 'Reminder';
+      const messageToShow = reminder.enhancedDescription || reminder.originalMessage;
+      const truncatedMessage = messageToShow.length > 100 ? messageToShow.substring(0, 100) + '...' : messageToShow;
+      const notificationInfo = reminder.notifyInDM ? '📩 DM' : `📢 ${reminder.channelMention || 'Channel'}`;
+      const timeRemaining = formatTimeRemaining(reminder.reminderTime);
+
+      embed.addFields({
+        name: `${status} - ${title} (ID: ${reminder.id})`,
+        value: `📝 ${truncatedMessage}\n${timeDisplay} (${timeRemaining})\n📍 ${notificationInfo}`,
+        inline: false
+      });
+    }
+
+    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(`remindlist_${page - 1}_${showAll ? 1 : 0}`)
+        .setLabel('Previous')
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(page <= 0),
+      new ButtonBuilder()
+        .setCustomId(`remindlist_${page + 1}_${showAll ? 1 : 0}`)
+        .setLabel('Next')
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(page >= totalPages - 1)
+    );
+
+    await interaction.update({ embeds: [embed], components: [row] });
+  }
+};

--- a/src/plugins/remind/remindPlugin.ts
+++ b/src/plugins/remind/remindPlugin.ts
@@ -6,6 +6,7 @@ import { remind } from './commands/remind';
 import { reminderChecker } from './events/reminderChecker';
 import { reminderButtonHandler } from './events/reminderButtonHandler';
 import { reminderModalHandler } from './events/reminderModalHandler';
+import { reminderListPaginationHandler } from './events/reminderListPaginationHandler';
 import chalk from 'chalk';
 
 export const remindPlugin: Plugin = {
@@ -13,7 +14,7 @@ export const remindPlugin: Plugin = {
     description: 'Plugin to remind users of tasks or events with AI enhancement and interactive controls',
     authors: ['GuikiPT'],
     commands: [remind],
-    events: [reminderChecker, reminderButtonHandler, reminderModalHandler],
+    events: [reminderChecker, reminderButtonHandler, reminderModalHandler, reminderListPaginationHandler],
     async load(client: Client) {
         // Initialize Google AI for reminder enhancement
         const aiInitialized = initializeGoogleAI();


### PR DESCRIPTION
## Summary
- deduplicate SubcommandHandler interface usage in remind plugin
- add pagination for listing reminders with new interaction handler
- update remind plugin to register pagination event
- adjust remind command implementation for unified `execute` function

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68679ef0a0888325a70b885693a69f8c